### PR TITLE
Apply greyscale filter to site

### DIFF
--- a/frontend/src/main/resources/styling/style.css
+++ b/frontend/src/main/resources/styling/style.css
@@ -1,3 +1,8 @@
+html {
+    -webkit-filter: grayscale(100%);
+            filter: grayscale(100%);
+}
+
 body {
     margin: 5px;
     background-color: #FFFFFF;


### PR DESCRIPTION
Add a global grayscale filter to render the entire site in black and white.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ea86db0-bc59-4e65-bb4d-75107ee75644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ea86db0-bc59-4e65-bb4d-75107ee75644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

