### PR TITLE
Add subtle swipe to delete indicator

### DIFF
--- a/frontend/src/main/resources/styling/style.css
+++ b/frontend/src/main/resources/styling/style.css
@@ -194,6 +194,26 @@ body {
     filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(100%) contrast(100%);
 }
 
+/* Subtle swipe hint enhancements (grayscale-safe) */
+.swipe-hint-icon {
+    width: 18px;
+    height: 18px;
+    opacity: 0.95;
+}
+
+.rotate-left {
+    transform: rotate(90deg);
+}
+
+.swipe-hint-breath {
+    animation: swipe-nudge-mr 1.6s ease-in-out infinite alternate;
+}
+
+@keyframes swipe-nudge-mr {
+    from { margin-right: 0; }
+    to { margin-right: 3px; }
+}
+
 /* Make the time scrolling wheel only as wide as its content and center it
    so there is dead space on either side for dragging the page */
 .scrolling-wheel {

--- a/frontend/src/main/scala/crestedbutte/laminar/Components.scala
+++ b/frontend/src/main/scala/crestedbutte/laminar/Components.scala
@@ -410,9 +410,9 @@ object Components {
       ),
       div(
         styleAttr :=
-          "position: absolute; top: 50%; right: 10px; transform: translateY(-50%); pointer-events: none; z-index: 5; font-size: 18px; line-height: 1; color: rgba(255,255,255,0.85);",
+          "position: absolute; top: 50%; right: 10px; transform: translateY(-50%); pointer-events: none; z-index: 5;",
         styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 4) "1" else "0"),
-        "‹",
+        SvgIcon.arrowDown("filter-white swipe-hint-icon rotate-left swipe-hint-breath"),
       ),
     )
 

--- a/frontend/src/main/scala/crestedbutte/laminar/Components.scala
+++ b/frontend/src/main/scala/crestedbutte/laminar/Components.scala
@@ -405,12 +405,12 @@ object Components {
       // Subtle right-edge swipe hint (non-interactive)
       div(
         styleAttr :=
-          "position: absolute; top: 0; right: 0; height: 100%; width: 28px; pointer-events: none; background: linear-gradient(to left, rgba(0,0,0,0.06), rgba(0,0,0,0)); z-index: 2;",
+          "position: absolute; top: 0; right: 0; height: 100%; width: 28px; pointer-events: none; background: linear-gradient(to left, rgba(255,255,255,0.12), rgba(255,255,255,0)); z-index: 2;",
         styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 2) "0.35" else "0"),
       ),
       div(
         styleAttr :=
-          "position: absolute; top: 50%; right: 8px; transform: translateY(-50%); pointer-events: none; z-index: 2; font-size: 16px; line-height: 1; color: rgba(0,0,0,0.45);",
+          "position: absolute; top: 50%; right: 8px; transform: translateY(-50%); pointer-events: none; z-index: 2; font-size: 16px; line-height: 1; color: rgba(255,255,255,0.7);",
         styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 2) "1" else "0"),
         "‹",
       ),

--- a/frontend/src/main/scala/crestedbutte/laminar/Components.scala
+++ b/frontend/src/main/scala/crestedbutte/laminar/Components.scala
@@ -405,13 +405,13 @@ object Components {
       // Subtle right-edge swipe hint (non-interactive)
       div(
         styleAttr :=
-          "position: absolute; top: 0; right: 0; height: 100%; width: 28px; pointer-events: none; background: linear-gradient(to left, rgba(255,255,255,0.12), rgba(255,255,255,0)); z-index: 2;",
-        styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 2) "0.35" else "0"),
+          "position: absolute; top: 0; right: 0; height: 100%; width: 36px; pointer-events: none; background: linear-gradient(to left, rgba(255,255,255,0.35), rgba(255,255,255,0)); border-left: 1px solid rgba(255,255,255,0.25); z-index: 5;",
+        styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 4) "0.6" else "0"),
       ),
       div(
         styleAttr :=
-          "position: absolute; top: 50%; right: 8px; transform: translateY(-50%); pointer-events: none; z-index: 2; font-size: 16px; line-height: 1; color: rgba(255,255,255,0.7);",
-        styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 2) "1" else "0"),
+          "position: absolute; top: 50%; right: 10px; transform: translateY(-50%); pointer-events: none; z-index: 5; font-size: 18px; line-height: 1; color: rgba(255,255,255,0.85);",
+        styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 4) "1" else "0"),
         "‹",
       ),
     )

--- a/frontend/src/main/scala/crestedbutte/laminar/Components.scala
+++ b/frontend/src/main/scala/crestedbutte/laminar/Components.scala
@@ -402,6 +402,18 @@ object Components {
           wheelElement,
         ),
       ),
+      // Subtle right-edge swipe hint (non-interactive)
+      div(
+        styleAttr :=
+          "position: absolute; top: 0; right: 0; height: 100%; width: 28px; pointer-events: none; background: linear-gradient(to left, rgba(0,0,0,0.06), rgba(0,0,0,0)); z-index: 2;",
+        styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 2) "0.35" else "0"),
+      ),
+      div(
+        styleAttr :=
+          "position: absolute; top: 50%; right: 8px; transform: translateY(-50%); pointer-events: none; z-index: 2; font-size: 16px; line-height: 1; color: rgba(0,0,0,0.45);",
+        styleProp("opacity") <-- offsetPx.signal.map(px => if (px <= 2) "1" else "0"),
+        "‹",
+      ),
     )
 
   }


### PR DESCRIPTION
Add subtle visual indicators to route segments to improve discoverability of swipe-to-delete.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bd86966-c074-4b66-8ce3-e52bbba6ddf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bd86966-c074-4b66-8ce3-e52bbba6ddf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

