### PR TITLE
Add notification permission button

### DIFF
--- a/frontend/src/main/scala/crestedbutte/laminar/Components.scala
+++ b/frontend/src/main/scala/crestedbutte/laminar/Components.scala
@@ -105,6 +105,24 @@ object Components {
           ),
         ),
       ),
+      // Notification permission button at the bottom
+      div(
+        cls := "notification-permission-container",
+        styleAttr := "position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; width: auto;",
+        child <-- Signal.fromValue(()).map { _ =>
+          if (dom.Notification.permission == "granted") {
+            div() // Don't show button if permission already granted
+          } else {
+            button(
+              idAttr := ElementNames.Notifications.requestPermission,
+              cls := "button",
+              styleAttr := "padding: 0.75rem 1.5rem; box-shadow: 0 2px 8px rgba(0,0,0,0.3);",
+              "Enable Notifications",
+              onClick --> Experimental.Notifications.clickObserver,
+            )
+          }
+        },
+      ),
     )
   }
 


### PR DESCRIPTION
Add a button at the bottom of the app to request notification permission.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc5ef499-6229-4790-a1a9-ef1f39e97e2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc5ef499-6229-4790-a1a9-ef1f39e97e2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

